### PR TITLE
add anti-aliasing to rounded corners

### DIFF
--- a/src/rounded-blur-effect.c
+++ b/src/rounded-blur-effect.c
@@ -39,7 +39,8 @@ static const gchar *mask_glsl =
 "  vec2 p  = uv * u_size;                                                  \n"
 "  vec2 q  = abs(p - 0.5 * u_size) - (0.5 * u_size - u_corner_radius);     \n"
 "  float dist = length(max(q, vec2(0.0))) - u_corner_radius;               \n"
-"  float m = step(dist, 0.0);                                              \n"
+"  float aa = max(fwidth(dist) * 0.5, 0.5);                                \n"
+"  float m = 1.0 - smoothstep(-aa, aa, dist);                              \n"
 "  cogl_color_out.rgb *= m;                                                \n"
 "  cogl_color_out.a   *= m;                                                \n";
 

--- a/src/rounded-blur-effect.c
+++ b/src/rounded-blur-effect.c
@@ -36,11 +36,20 @@ static const gchar *mask_glsl_declarations =
 
 static const gchar *mask_glsl =
 "  vec2 uv = cogl_tex_coord_in[0].st;                                      \n"
-"  vec2 p  = uv * u_size;                                                  \n"
-"  vec2 q  = abs(p - 0.5 * u_size) - (0.5 * u_size - u_corner_radius);     \n"
-"  float dist = length(max(q, vec2(0.0))) - u_corner_radius;               \n"
-"  float aa = max(fwidth(dist) * 0.5, 0.5);                                \n"
-"  float m = 1.0 - smoothstep(-aa, aa, dist);                              \n"
+"  vec2 size = max(u_size, vec2(1.0));                                     \n"
+"  vec2 half_size = max(size * 0.5, vec2(0.5));                            \n"
+"  float radius = clamp(u_corner_radius,                                   \n"
+"                       0.0,                                               \n"
+"                       max(min(half_size.x, half_size.y) - 0.5, 0.0));    \n"
+"  float m = 1.0;                                                          \n"
+"  if (radius > 0.0)                                                       \n"
+"    {                                                                     \n"
+"      vec2 p = uv * size;                                                 \n"
+"      vec2 q = abs(p - half_size) - max(half_size - radius, vec2(0.0));   \n"
+"      float dist = length(max(q, vec2(0.0))) - radius;                    \n"
+"      float aa = max(fwidth(dist) * 0.5, 0.5);                            \n"
+"      m = 1.0 - smoothstep(-aa, aa, dist);                                \n"
+"    }                                                                     \n"
 "  cogl_color_out.rgb *= m;                                                \n"
 "  cogl_color_out.a   *= m;                                                \n";
 


### PR DESCRIPTION
Adds anti-aliasing to the rounded corner mask by replacing the hard `step()` cutoff with a narrow `smoothstep()` transition.

The previous shader produced visibly pixelated rounded corners because the mask alpha was binary. This change softens only the edge boundary, keeping the rounded dock crisp while reducing jagged corners.
